### PR TITLE
Fix usage section of readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ LocalStorage only works with key/value pairs where value is a string. Dojo-local
         var id = store.add({
             title: 'Elementarteilchen',
             year: 2006
+        },{
+            id: 'abc'
         });
         
         // querying the store
@@ -41,7 +43,7 @@ LocalStorage only works with key/value pairs where value is a string. Dojo-local
         });
         
         // getting an object
-        var object = store.put('abc');
+        var object = store.get('abc');
         
         // deleting an object
         store.remove('abc');


### PR DESCRIPTION
Use the same id for the object being used, so that it is really updated.
Fix using put() instead of get().

The comments claim that an object is being updated, but this is not the object we stored first. The first object lacked an id (either via options.id as in this patch or as an attribute) and hence its id was being autogenerated. This means that the update lateron did in fact add a new object (with id 'abc') instead of being an update.
