### PR TITLE
Fix add() to respect options.id

### DIFF
--- a/LocalStorage.js
+++ b/LocalStorage.js
@@ -112,7 +112,8 @@ define([
             //      Additional metadata for storing the data. Includes an "id"
             //      property if a specific id is to be used.
             // returns: Number
-            if (this.get(object[this.idProperty])) {
+            var id = (options && options.id) || object[this.idProperty];
+            if (this.get(id)) {
                 throw new Error("Object already exists");
             }
 


### PR DESCRIPTION
Use _options.id_ with priority if given, just like _add()_'s own documentation and _put()_.

This also fixes the existance check by preventing _put()_ from storing an object with different id via _options.id_.
If there's no testcase for this already, one should be added.

If both _options.id_ and _object[this.idProperty]_ are undefined, the existance check will probe for an item with undefined id. If this is not intended, an id should be generated as in _put()_ itself (preferably moving the code into a helper method as well).
