### PR TITLE
Fix npm warning about repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,9 @@
     "devDependencies": {
         "intern": "~1.4.0",
         "dojo": "~1.9.2"
+    },
+    "repository": {
+		"type": "git",
+		"url": "https://github.com/sirprize/dojo-local-storage.git"
     }
 }


### PR DESCRIPTION
`npm install` complains when the "repository" metadata is missing
https://www.npmjs.org/doc/json.html#repository

```
npm WARN package.json dojo-local-storage@0.1.0 No repository field.
```
